### PR TITLE
Set Ansible to use Python 3

### DIFF
--- a/hosts
+++ b/hosts
@@ -3,3 +3,5 @@ localhost
 
 [local:vars]
 ansible_connection=local
+ansible_python_interpreter=/usr/bin/python3
+


### PR DESCRIPTION
This is to ensure compatibility with Fedora 30.