### PR TITLE
Fixed Google Chrome Installation

### DIFF
--- a/roles/tools/tasks/main.yml
+++ b/roles/tools/tasks/main.yml
@@ -1,17 +1,6 @@
 ---
 # Installs web browsers, and system utilities
 
-- name: Add Google Chrome repo
-  yum_repository:
-    name: google-chrome
-    description: google-chrome - $basearch
-    baseurl: http://dl.google.com/linux/chrome/rpm/stable/$basearch
-    gpgkey: https://dl-ssl.google.com/linux/linux_signing_key.pub
-    gpgcheck: yes
-    repo_gpgcheck: yes
-    enabled: yes
-    state: present
-
 ##### System Utils #####
 
 - name: install the latest version of htop
@@ -37,5 +26,5 @@
 
 - name: install the latest stable version of Google chrome
   dnf:
-    name: google-chrome-stable
+    name: 'https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm'
     state: latest


### PR DESCRIPTION
Before, the Google Chrome repo was installed then the google-chrome-stable package was downloaded and installed from it.

Now, Google Chrome and the Google Chrome repo installed using Google's Chrome installation package for Fedora.